### PR TITLE
Gp5 reading pipeline optimization

### DIFF
--- a/src/Cli.Console/Cli.Console.csproj
+++ b/src/Cli.Console/Cli.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>$(SolutionName).$(MSBuildProjectName)</AssemblyName>

--- a/src/Engine.Core.Score/Engine.Core.Score.csproj
+++ b/src/Engine.Core.Score/Engine.Core.Score.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>$(SolutionName).$(MSBuildProjectName)</AssemblyName>

--- a/src/Engine.Core/Engine.Core.csproj
+++ b/src/Engine.Core/Engine.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>$(SolutionName).$(MSBuildProjectName)</AssemblyName>

--- a/src/Engine.Core/FileSerialization/Common/Components/SerialFileReader/ISerialFileReader.cs
+++ b/src/Engine.Core/FileSerialization/Common/Components/SerialFileReader/ISerialFileReader.cs
@@ -8,6 +8,8 @@ internal interface ISerialFileReader : IDisposable
     long Length { get; }
     long Position { get; }
 
+    delegate T TODO_Delegate_Name<T>(ReadOnlySpan<byte> buffer);
+
     ValueTask<byte[]> ReadBytesAsync(int count);
     ValueTask SkipBytesAsync(int count);
 }

--- a/src/Engine.Core/FileSerialization/Common/Components/SerialFileReader/ISerialFileReader.cs
+++ b/src/Engine.Core/FileSerialization/Common/Components/SerialFileReader/ISerialFileReader.cs
@@ -8,8 +8,8 @@ internal interface ISerialFileReader : IDisposable
     long Length { get; }
     long Position { get; }
 
-    delegate T TODO_Delegate_Name<T>(ReadOnlySpan<byte> buffer);
+    delegate T Convert<T>(ReadOnlySpan<byte> buffer);
 
-    ValueTask<byte[]> ReadBytesAsync(int count);
+    ValueTask<T> ReadBytesAsync<T>(int count, Convert<T> convert);
     ValueTask SkipBytesAsync(int count);
 }

--- a/src/Engine.Core/FileSerialization/Common/Components/SerialFileReader/PocSerialFileReader.cs
+++ b/src/Engine.Core/FileSerialization/Common/Components/SerialFileReader/PocSerialFileReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
 using TabAmp.Engine.Core.FileSerialization.Common.Components.Context;
@@ -8,6 +9,7 @@ namespace TabAmp.Engine.Core.FileSerialization.Common.Components.SerialFileReade
 internal class PocSerialFileReader : ISerialFileReader
 {
     private readonly FileStream _fileStream;
+    private readonly ArrayPool<byte> _arrayPool;
     private readonly FileSerializationContext _context;
 
     public PocSerialFileReader(FileSerializationContext context)
@@ -18,6 +20,7 @@ internal class PocSerialFileReader : ISerialFileReader
             Share = FileShare.None
         };
         _fileStream = File.Open(context.FilePath, options);
+        _arrayPool = ArrayPool<byte>.Shared;
         _context = context;
     }
 

--- a/src/Engine.Core/FileSerialization/GuitarPro/Gp5/Deserialization/Gp5FileDeserializer.cs
+++ b/src/Engine.Core/FileSerialization/GuitarPro/Gp5/Deserialization/Gp5FileDeserializer.cs
@@ -17,9 +17,15 @@ internal class Gp5FileDeserializer : Gp5FileSerializationProcessor, IFileDeseria
     private readonly IGp5MeasuresReader _measuresReader;
 
     public Gp5FileDeserializer(IGp5DocumentComponentsReader documentReader, IGp5MusicalNotationReader notationReader,
-        IGp5TracksReader tracksReader, IGp5MeasuresReader measuresReader) =>
-        (_documentReader, _notationReader, _tracksReader, _measuresReader) =
-        (documentReader, notationReader, tracksReader, measuresReader);
+        IGp5TracksReader tracksReader, IGp5MeasuresReader measuresReader)
+    {
+        _documentReader = documentReader;
+        _notationReader = notationReader;
+        _tracksReader = tracksReader;
+        _measuresReader = measuresReader;
+
+        ReadNotesAsync = NextNotesAsync;
+    }
 
     public async Task<Gp5Score> DeserializeAsync()
     {
@@ -97,7 +103,9 @@ internal class Gp5FileDeserializer : Gp5FileSerializationProcessor, IFileDeseria
         File.MeasureBeats[measureIndex] = new Gp5Beat[await _measuresReader.ReadMeasureBeatsCountAsync()];
 
     protected override async ValueTask NextBeatAsync(int measureIndex, int beatIndex) =>
-        File.MeasureBeats[measureIndex][beatIndex] = await _measuresReader.ReadBeatAsync(NextNotesAsync);
+        File.MeasureBeats[measureIndex][beatIndex] = await _measuresReader.ReadBeatAsync(ReadNotesAsync);
+
+    private Func<Gp5Beat, ValueTask> ReadNotesAsync { get; }
 
     protected override ValueTask NextNotesAsync(Gp5Beat beat)
     {

--- a/src/Engine.Core/FileSerialization/GuitarPro/Gp5/Deserialization/Readers/Gp5TextReader.cs
+++ b/src/Engine.Core/FileSerialization/GuitarPro/Gp5/Deserialization/Readers/Gp5TextReader.cs
@@ -40,9 +40,8 @@ internal class Gp5TextReader : IGp5TextReader
         return new Gp5IntByteText(decodedString, size);
     }
 
-    private async ValueTask<string> ReadStringAsync(int length)
-    {
-        var buffer = await _fileReader.ReadBytesAsync(length);
-        return Encoding.UTF8.GetString(buffer);
-    }
+    private ValueTask<string> ReadStringAsync(int length) =>
+        _fileReader.ReadBytesAsync(length, ConvertToString);
+
+    private static ISerialFileReader.Convert<string> ConvertToString { get; } = Encoding.UTF8.GetString;
 }

--- a/src/Engine.Core/FileSerialization/GuitarPro/Gp5/Models/BinaryPrimitives/Gp5Color.cs
+++ b/src/Engine.Core/FileSerialization/GuitarPro/Gp5/Models/BinaryPrimitives/Gp5Color.cs
@@ -1,4 +1,6 @@
-﻿namespace TabAmp.Engine.Core.FileSerialization.GuitarPro.Gp5.Models.BinaryPrimitives;
+﻿using System;
+
+namespace TabAmp.Engine.Core.FileSerialization.GuitarPro.Gp5.Models.BinaryPrimitives;
 
 internal readonly struct Gp5Color
 {
@@ -14,7 +16,7 @@ internal readonly struct Gp5Color
         _A01 = _a01;
     }
 
-    public static explicit operator Gp5Color(byte[] buffer) =>
+    public static explicit operator Gp5Color(ReadOnlySpan<byte> buffer) =>
         new(red: buffer[0], green: buffer[1], blue: buffer[2], _a01: buffer[3]);
 
 

--- a/src/Engine.GuitarProFileFormat/Engine.GuitarProFileFormat.csproj
+++ b/src/Engine.GuitarProFileFormat/Engine.GuitarProFileFormat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>$(SolutionName).$(MSBuildProjectName)</AssemblyName>


### PR DESCRIPTION
### In `PocSerialFileReader.cs`:
```c#
public async ValueTask<byte[]> ReadBytesAsync(int count)
{
    var buffer = new byte[count];
    await _fileStream.ReadAsync(buffer, _context.CancellationToken);
    Position += count;
    return buffer;
}
``` 
Each time the `ReadBytesAsync` method is called a new instance of byte array is allocated, resulting in the following benchmark results:

```
| Method        | Mean     | Error     | StdDev    | Gen0     | Gen1     | Allocated |
|-------------- |---------:|----------:|----------:|---------:|---------:|----------:|
| ReadFileAsync | 4.808 ms | 0.0373 ms | 0.0330 ms | 218.7500 | 140.6250 |   2.64 MB |
``` 
(_reading .gp5 file of 59,900 bytes, 4 tracks, 94 measures, measures primarily composed of 18 single-note beats_)

### Changed implementation to use `ArrayPool<byte>`:
```c#
public async ValueTask<T> ReadBytesAsync<T>(int count, ConvertTo<T> convertTo)
{
    byte[]? buffer = null;

    try
    {
        buffer = _arrayPool.Rent(count);

        await _fileStream.ReadExactlyAsync(buffer, offset: 0, count, _context.CancellationToken);
        Position += count;

        return convertTo(buffer.AsSpan(start: 0, count));
    }
    finally
    {
        if (buffer != null) _arrayPool.Return(buffer);
    }
}
``` 
(_the `ConvertTo<T>` delegate was introduced to reader API in order to manage the ownership of leased memory effectively without relying on client code to correctly dispose arrays rented from array pool_)
```
| Method        | Mean     | Error     | StdDev    | Gen0     | Gen1    | Allocated |
|-------------- |---------:|----------:|----------:|---------:|--------:|----------:|
| ReadFileAsync | 4.349 ms | 0.0464 ms | 0.0411 ms | 101.5625 | 78.1250 |   1.22 MB |
```
After a closer look at diagnostics data via Visual Studio Performance Profiler tools, the excessive allocation of delegate instances was discovered. 

Benchmark results after addressing the issue (fix [primitives, text reader](https://github.com/Dstrx03/TabAmp/pull/2/commits/e7775c1fd8f291ecfac0bab4b53806c0d12d70a1) and [desereializer](https://github.com/Dstrx03/TabAmp/pull/2/commits/b3b5396f0b6c7d41edae9402ac4e00d90d3c06da) delegates excessive allocation):
```
| Method        | Mean     | Error     | StdDev    | Gen0    | Gen1    | Allocated |
|-------------- |---------:|----------:|----------:|--------:|--------:|----------:|
| ReadFileAsync | 4.234 ms | 0.0622 ms | 0.0552 ms | 70.3125 | 31.2500 | 936.63 KB |
```